### PR TITLE
chore: add Ruff

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,17 +5,21 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				"python.pythonPath": "/usr/local/bin/python",
-				// "python.linting.pylintPath": "/usr/local/bin/pylint",
-				// "python.linting.enabled": true,
 				"python.testing.pytestArgs": [
 					"tests",
 					"-vv"
 				],
 				"python.testing.unittestEnabled": true,
 				"python.testing.pytestEnabled": true,
-				"python.linting.pylintEnabled": true,
-				"python.analysis.typeCheckingMode": "basic"
+				"python.analysis.typeCheckingMode": "basic",
+				"[python]": {
+					"editor.defaultFormatter": "charliermarsh.ruff",
+					"editor.codeActionsOnSave": {
+					    "source.fixAll.ruff": "explicit",
+					    "source.organizeImports.ruff": "explicit"
+					},
+					"editor.formatOnSave": true
+				    },
 			},
 			"extensions": [
 				"mhutchie.git-graph",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,9 @@
         "-vv"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
     "python.testing.pytestEnabled": true,
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true,
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,18 @@
 RYE=rye
 PYTEST=$(RYE) run pytest
 MYPY=$(RYE) run mypy --ignore-missing-imports
-BLACK=$(RYE) run black
-ISORT=$(RYE) run isort
-PYLINT=$(RYE) run pylint
 UVICORN=$(RYE) run uvicorn
 PACKAGE=dddpy
 
-install:
+sync:
 	$(RYE) sync
-	$(POETRY_EXPORT)
-
-update:
-	$(POETRY) sync
 
 test: install  
 	$(MYPY) main.py ./${PACKAGE}/
-	$(PYTEST) -vv
+	$(PYTEST) -vv 
 
-fmt:
-	$(ISORT) main.py ./${PACKAGE} ./tests
-	$(BLACK) main.py ./${PACKAGE} ./tests
-
-lint:
-	$(PYLINT) main.py ./${PACKAGE} ./tests
+format:
+	$(RYE) run ruff format
 
 dev:
 	${UVICORN} main:app --reload

--- a/dddpy/infrastructure/sqlite/book/__init__.py
+++ b/dddpy/infrastructure/sqlite/book/__init__.py
@@ -1,3 +1,6 @@
 from .book_dto import BookDTO
 from .book_query_service import BookQueryServiceImpl
-from .book_repository import BookCommandUseCaseUnitOfWorkImpl, BookRepositoryImpl
+from .book_repository import (
+    BookCommandUseCaseUnitOfWorkImpl,
+    BookRepositoryImpl,
+)

--- a/main.py
+++ b/main.py
@@ -51,13 +51,17 @@ def get_session() -> Iterator[Session]:
         session.close()
 
 
-def book_query_usecase(session: Session = Depends(get_session)) -> BookQueryUseCase:
+def book_query_usecase(
+    session: Session = Depends(get_session),
+) -> BookQueryUseCase:
     """Get a book query use case."""
     book_query_service: BookQueryService = BookQueryServiceImpl(session)
     return BookQueryUseCaseImpl(book_query_service)
 
 
-def book_command_usecase(session: Session = Depends(get_session)) -> BookCommandUseCase:
+def book_command_usecase(
+    session: Session = Depends(get_session),
+) -> BookCommandUseCase:
     """Get a book command use case."""
     book_repository: BookRepository = BookRepositoryImpl(session)
     uow: BookCommandUseCaseUnitOfWork = BookCommandUseCaseUnitOfWorkImpl(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,9 @@ build-backend = "hatchling.build"
 [tool.rye]
 managed = true
 dev-dependencies = [
-    "black>=24.4.2",
     "mypy>=1.11.0",
     "pytest>=8.3.2",
-    "isort>=5.13.2",
-    "pylint>=3.2.6",
+    "ruff>=0.5.5",
 ]
 
 [tool.hatch.metadata]
@@ -32,3 +30,32 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["dddpy"]
+
+[tool.ruff]
+line-length = 88
+indent-width = 4
+
+target-version = "py312"
+
+[lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+fixable = ["ALL"]
+unfixable = []
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+ # Allow unused variables when underscore-prefixed.
+ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -16,18 +16,12 @@ anyio==4.4.0
     # via httpx
     # via starlette
     # via watchfiles
-astroid==3.2.4
-    # via pylint
-black==24.4.2
 certifi==2024.7.4
     # via httpcore
     # via httpx
 click==8.1.7
-    # via black
     # via typer
     # via uvicorn
-dill==0.3.8
-    # via pylint
 dnspython==2.6.1
     # via email-validator
 email-validator==2.2.0
@@ -53,30 +47,19 @@ idna==3.7
     # via httpx
 iniconfig==2.0.0
     # via pytest
-isort==5.13.2
-    # via pylint
 jinja2==3.1.4
     # via fastapi
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via jinja2
-mccabe==0.7.0
-    # via pylint
 mdurl==0.1.2
     # via markdown-it-py
 mypy==1.11.0
 mypy-extensions==1.0.0
-    # via black
     # via mypy
 packaging==24.1
-    # via black
     # via pytest
-pathspec==0.12.1
-    # via black
-platformdirs==4.2.2
-    # via black
-    # via pylint
 pluggy==1.5.0
     # via pytest
 pydantic==2.8.2
@@ -86,7 +69,6 @@ pydantic-core==2.20.1
     # via pydantic
 pygments==2.18.0
     # via rich
-pylint==3.2.6
 pytest==8.3.2
 python-dotenv==1.0.1
     # via uvicorn
@@ -96,6 +78,7 @@ pyyaml==6.0.1
     # via uvicorn
 rich==13.7.1
     # via typer
+ruff==0.5.5
 shellingham==1.5.4
     # via typer
 shortuuid==1.0.13
@@ -107,8 +90,6 @@ sqlalchemy==2.0.9
     # via dddpy
 starlette==0.37.2
     # via fastapi
-tomlkit==0.13.0
-    # via pylint
 typer==0.12.3
     # via fastapi-cli
 typing-extensions==4.12.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Transitioned to using `ruff` for code linting and formatting, replacing previous tools.
	- Enabled automatic code formatting on save within the development environment.

- **Bug Fixes**
	- Removed unused `nosetests` configuration to streamline testing settings.

- **Chores**
	- Simplified build commands in the Makefile for installation, testing, and formatting.
	- Updated development dependencies to enhance project coding standards and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->