### PR TITLE
refactor: remove calling datetime.now as default argument

### DIFF
--- a/dddpy/domain/todo/entities/todo.py
+++ b/dddpy/domain/todo/entities/todo.py
@@ -30,8 +30,8 @@ class Todo:
         title: TodoTitle,
         description: Optional[TodoDescription] = None,
         status: TodoStatus = TodoStatus.NOT_STARTED,
-        created_at: datetime = datetime.now(),
-        updated_at: datetime = datetime.now(),
+        created_at: Optional[datetime] = None,
+        updated_at: Optional[datetime] = None,
         completed_at: Optional[datetime] = None,
     ):
         """Initialize a todo domain entity.
@@ -49,8 +49,8 @@ class Todo:
         self._title = title
         self._description = description
         self._status = status
-        self._created_at = created_at
-        self._updated_at = updated_at
+        self._created_at = created_at or datetime.now()
+        self._updated_at = updated_at or datetime.now()
         self._completed_at = completed_at
 
     def __eq__(self, obj: object) -> bool:


### PR DESCRIPTION
Set `datetime.now()` defaults inside `Todo.__init__ ` only.

Any function call that's used in a default argument will only be performed once, at definition time. The returned value will then be reused by all calls to the function, which can lead to unexpected behaviour (See https://docs.astral.sh/ruff/rules/function-call-in-default-argument/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timestamp initialization for todos to capture the current time at creation rather than at module import, preventing todos from sharing identical creation and update timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->