### PR TITLE
chore: enforce repo-wide Ruff checks in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: |
           make install
+      - name: Run lint
+        run: |
+          make lint RUFF_FLAGS=--output-format=github
       - name: Run tests
         run: |
           make test PYREFLY_FLAGS=--output-format=github

--- a/.mise.toml
+++ b/.mise.toml
@@ -13,6 +13,10 @@ run = "uv venv .venv --allow-existing --seed"
 depends = ["venv"]
 run = "uv pip install -e '.[dev]' --python .venv/bin/python"
 
+[tasks.lint]
+depends = ["install"]
+run = ".venv/bin/ruff check ."
+
 [tasks.test]
 depends = ["install"]
 run = ".venv/bin/pyrefly check --summarize-errors && .venv/bin/pytest -vv"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ UVICORN=$(VENV)/bin/uvicorn
 RUFF=$(VENV)/bin/ruff
 PACKAGE=dddpy
 PYREFLY_FLAGS=--summarize-errors
+RUFF_FLAGS=
+
+.PHONY: sync venv install lint typecheck test format dev
 
 sync:
 	uv sync
@@ -14,6 +17,9 @@ venv:
 
 install: venv
 	uv pip install -e ".[dev]" --python $(VENV)/bin/python
+
+lint: install
+	$(RUFF) check . $(RUFF_FLAGS)
 
 typecheck: install
 	$(PYREFLY) check $(PYREFLY_FLAGS)

--- a/dddpy/domain/todo/entities/todo.py
+++ b/dddpy/domain/todo/entities/todo.py
@@ -1,7 +1,7 @@
 """Define the Todo entity used throughout the domain layer."""
 
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
 
 from dddpy.domain.todo.value_objects import (
     TodoDescription,
@@ -10,89 +10,41 @@ from dddpy.domain.todo.value_objects import (
     TodoTitle,
 )
 
+ALREADY_COMPLETED_ERROR_MESSAGE = 'Already completed'
 
+
+@dataclass(eq=False)
 class Todo:
     """Represent a todo item tracked by the domain.
 
     Attributes:
-        _id: Unique identifier for the todo.
-        _title: Title describing the todo.
-        _description: Optional detailed description.
-        _status: Current lifecycle status.
-        _created_at: Timestamp when the todo was created.
-        _updated_at: Timestamp when the todo was last updated.
-        _completed_at: Optional timestamp when the todo was completed.
+        id: Unique identifier for the todo.
+        title: Title describing the todo.
+        description: Optional detailed description.
+        status: Current lifecycle status.
+        created_at: Timestamp when the todo was created.
+        updated_at: Timestamp when the todo was last updated.
+        completed_at: Optional timestamp when the todo was completed.
     """
 
-    def __init__(
-        self,
-        id: TodoId,
-        title: TodoTitle,
-        description: Optional[TodoDescription] = None,
-        status: TodoStatus = TodoStatus.NOT_STARTED,
-        created_at: datetime = datetime.now(),
-        updated_at: datetime = datetime.now(),
-        completed_at: Optional[datetime] = None,
-    ):
-        """Initialize a todo domain entity.
+    id: TodoId
+    title: TodoTitle
+    description: TodoDescription | None = None
+    status: TodoStatus = TodoStatus.NOT_STARTED
+    created_at: datetime = field(default_factory=datetime.now)
+    updated_at: datetime = field(default_factory=datetime.now)
+    completed_at: datetime | None = None
 
-        Args:
-            id: Identifier for the todo.
-            title: Title describing the todo.
-            description: Optional longer description.
-            status: Initial lifecycle status.
-            created_at: Creation timestamp in UTC.
-            updated_at: Last updated timestamp in UTC.
-            completed_at: Optional completion timestamp in UTC.
-        """
-        self._id = id
-        self._title = title
-        self._description = description
-        self._status = status
-        self._created_at = created_at
-        self._updated_at = updated_at
-        self._completed_at = completed_at
+    def __hash__(self) -> int:
+        """Return a hash value based on the entity identity."""
+        return hash(self.id)
 
     def __eq__(self, obj: object) -> bool:
+        """Compare todos by identifier."""
         if isinstance(obj, Todo):
             return self.id == obj.id
 
         return False
-
-    @property
-    def id(self) -> TodoId:
-        """Return the todo's unique identifier."""
-        return self._id
-
-    @property
-    def title(self) -> TodoTitle:
-        """Return the todo's title."""
-        return self._title
-
-    @property
-    def description(self) -> Optional[TodoDescription]:
-        """Return the todo's description if available."""
-        return self._description
-
-    @property
-    def status(self) -> TodoStatus:
-        """Return the todo's current status."""
-        return self._status
-
-    @property
-    def created_at(self) -> datetime:
-        """Return the todo's creation timestamp."""
-        return self._created_at
-
-    @property
-    def updated_at(self) -> datetime:
-        """Return the todo's last update timestamp."""
-        return self._updated_at
-
-    @property
-    def completed_at(self) -> Optional[datetime]:
-        """Return the todo's completion timestamp if set."""
-        return self._completed_at
 
     def update_title(self, new_title: TodoTitle) -> None:
         """Update the todo title and refresh timestamps.
@@ -100,22 +52,22 @@ class Todo:
         Args:
             new_title: Replacement title for the todo.
         """
-        self._title = new_title
-        self._updated_at = datetime.now()
+        self.title = new_title
+        self.updated_at = datetime.now()
 
-    def update_description(self, new_description: Optional[TodoDescription]) -> None:
+    def update_description(self, new_description: TodoDescription | None) -> None:
         """Update the todo description and refresh timestamps.
 
         Args:
             new_description: Optional replacement description.
         """
-        self._description = new_description if new_description else None
-        self._updated_at = datetime.now()
+        self.description = new_description if new_description else None
+        self.updated_at = datetime.now()
 
     def start(self) -> None:
         """Mark the todo as in progress and update timestamps."""
-        self._status = TodoStatus.IN_PROGRESS
-        self._updated_at = datetime.now()
+        self.status = TodoStatus.IN_PROGRESS
+        self.updated_at = datetime.now()
 
     def complete(self) -> None:
         """Mark the todo as completed and record completion time.
@@ -123,20 +75,20 @@ class Todo:
         Raises:
             ValueError: If the todo is already completed.
         """
-        if self._status == TodoStatus.COMPLETED:
-            raise ValueError('Already completed')
+        if self.status == TodoStatus.COMPLETED:
+            raise ValueError(ALREADY_COMPLETED_ERROR_MESSAGE)
 
-        self._status = TodoStatus.COMPLETED
-        self._completed_at = datetime.now()
-        self._updated_at = self._completed_at
+        self.status = TodoStatus.COMPLETED
+        self.completed_at = datetime.now()
+        self.updated_at = self.completed_at
 
     @property
     def is_completed(self) -> bool:
         """Return whether the todo is marked as completed."""
-        return self._status == TodoStatus.COMPLETED
+        return self.status == TodoStatus.COMPLETED
 
     def is_overdue(
-        self, deadline: datetime, current_time: Optional[datetime] = None
+        self, deadline: datetime, current_time: datetime | None = None
     ) -> bool:
         """Determine whether the todo has passed the provided deadline.
 
@@ -152,9 +104,7 @@ class Todo:
         return (current_time or datetime.now()) > deadline
 
     @staticmethod
-    def create(
-        title: TodoTitle, description: Optional[TodoDescription] = None
-    ) -> 'Todo':
+    def create(title: TodoTitle, description: TodoDescription | None = None) -> 'Todo':
         """Create a new todo entity with generated identifier.
 
         Args:

--- a/dddpy/domain/todo/repositories/todo_repository.py
+++ b/dddpy/domain/todo/repositories/todo_repository.py
@@ -1,7 +1,6 @@
 """Define the repository abstraction for todo entities."""
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
 
 from dddpy.domain.todo.entities import Todo
 from dddpy.domain.todo.value_objects import TodoId
@@ -19,7 +18,7 @@ class TodoRepository(ABC):
         """
 
     @abstractmethod
-    def find_by_id(self, todo_id: TodoId) -> Optional[Todo]:
+    def find_by_id(self, todo_id: TodoId) -> Todo | None:
         """Retrieve a todo by its identifier.
 
         Args:
@@ -30,7 +29,7 @@ class TodoRepository(ABC):
         """
 
     @abstractmethod
-    def find_all(self) -> List[Todo]:
+    def find_all(self) -> list[Todo]:
         """Return the collection of todos stored in the repository.
 
         Returns:

--- a/dddpy/domain/todo/value_objects/todo_description.py
+++ b/dddpy/domain/todo/value_objects/todo_description.py
@@ -2,6 +2,9 @@
 
 from dataclasses import dataclass
 
+MAX_DESCRIPTION_LENGTH = 1000
+DESCRIPTION_TOO_LONG_ERROR_MESSAGE = 'Description must be 1000 characters or less'
+
 
 @dataclass(frozen=True)
 class TodoDescription:
@@ -15,8 +18,8 @@ class TodoDescription:
         Raises:
             ValueError: If the description exceeds 1000 characters.
         """
-        if len(self.value) > 1000:
-            raise ValueError('Description must be 1000 characters or less')
+        if len(self.value) > MAX_DESCRIPTION_LENGTH:
+            raise ValueError(DESCRIPTION_TOO_LONG_ERROR_MESSAGE)
 
     def __str__(self) -> str:
         """Return the wrapped description string."""

--- a/dddpy/domain/todo/value_objects/todo_title.py
+++ b/dddpy/domain/todo/value_objects/todo_title.py
@@ -2,6 +2,10 @@
 
 from dataclasses import dataclass
 
+MAX_TITLE_LENGTH = 100
+TITLE_REQUIRED_ERROR_MESSAGE = 'Title is required'
+TITLE_TOO_LONG_ERROR_MESSAGE = 'Title must be 100 characters or less'
+
 
 @dataclass(frozen=True)
 class TodoTitle:
@@ -16,9 +20,9 @@ class TodoTitle:
             ValueError: If the title is empty or longer than 100 characters.
         """
         if not self.value:
-            raise ValueError('Title is required')
-        if len(self.value) > 100:
-            raise ValueError('Title must be 100 characters or less')
+            raise ValueError(TITLE_REQUIRED_ERROR_MESSAGE)
+        if len(self.value) > MAX_TITLE_LENGTH:
+            raise ValueError(TITLE_TOO_LONG_ERROR_MESSAGE)
 
     def __str__(self) -> str:
         """Return the wrapped title string."""

--- a/dddpy/infrastructure/di/injection.py
+++ b/dddpy/infrastructure/di/injection.py
@@ -1,6 +1,6 @@
 """Dependency injection configuration for the application."""
 
-from typing import Iterator
+from collections.abc import Iterator
 
 from fastapi import Depends
 from sqlalchemy.orm import Session

--- a/dddpy/infrastructure/sqlite/todo/todo_repository.py
+++ b/dddpy/infrastructure/sqlite/todo/todo_repository.py
@@ -1,7 +1,5 @@
 """SQLite implementation of Todo repository."""
 
-from typing import List, Optional
-
 from sqlalchemy import desc
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm.session import Session
@@ -23,7 +21,7 @@ class TodoRepositoryImpl(TodoRepository):
         """
         self.session = session
 
-    def find_by_id(self, todo_id: TodoId) -> Optional[Todo]:
+    def find_by_id(self, todo_id: TodoId) -> Todo | None:
         """Return a todo matching the provided identifier.
 
         Args:
@@ -39,7 +37,7 @@ class TodoRepositoryImpl(TodoRepository):
 
         return row.to_entity()
 
-    def find_all(self) -> List[Todo]:
+    def find_all(self) -> list[Todo]:
         """Return todos ordered by creation date with an upper limit.
 
         Returns:

--- a/dddpy/presentation/api/todo/handlers/todo_api_route_handler.py
+++ b/dddpy/presentation/api/todo/handlers/todo_api_route_handler.py
@@ -1,6 +1,5 @@
 """Controller for handling Todo-related HTTP requests."""
 
-from typing import List
 from uuid import UUID
 
 from fastapi import Depends, FastAPI, HTTPException, status
@@ -9,6 +8,7 @@ from dddpy.domain.todo.exceptions import (
     TodoAlreadyCompletedError,
     TodoAlreadyStartedError,
     TodoNotFoundError,
+    TodoNotStartedError,
 )
 from dddpy.domain.todo.value_objects import TodoDescription, TodoId, TodoTitle
 from dddpy.infrastructure.di.injection import (
@@ -38,28 +38,42 @@ from dddpy.usecase.todo import (
 class TodoApiRouteHandler:
     """Register HTTP endpoints that expose todo use cases."""
 
-    def register_routes(self, app: FastAPI):
+    def register_routes(self, app: FastAPI) -> None:
         """Attach todo routes to the provided FastAPI application.
 
         Args:
             app: FastAPI instance that receives the todo routes.
         """
+        self._register_get_todos_route(app)
+        self._register_get_todo_route(app)
+        self._register_create_todo_route(app)
+        self._register_update_todo_route(app)
+        self._register_start_todo_route(app)
+        self._register_complete_todo_route(app)
+
+    @staticmethod
+    def _build_todo_description(description: str | None) -> TodoDescription | None:
+        """Convert an optional description string into a value object."""
+        return TodoDescription(description) if description else None
+
+    def _register_get_todos_route(self, app: FastAPI) -> None:
+        """Register the route that returns all todos."""
 
         @app.get(
             '/todos',
-            response_model=List[TodoSchema],
+            response_model=list[TodoSchema],
             status_code=200,
         )
         def get_todos(
             usecase: FindTodosUseCase = Depends(get_find_todos_usecase),
-        ):
+        ) -> list[TodoSchema]:
             """Return the latest todos.
 
             Args:
                 usecase: Use case responsible for retrieving todos.
 
             Returns:
-                List[TodoSchema]: Serialized todos returned to the client.
+                list[TodoSchema]: Serialized todos returned to the client.
 
             Raises:
                 HTTPException: When the use case raises an unexpected error.
@@ -71,6 +85,9 @@ class TodoApiRouteHandler:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 ) from e
+
+    def _register_get_todo_route(self, app: FastAPI) -> None:
+        """Register the route that returns a single todo."""
 
         @app.get(
             '/todos/{todo_id}',
@@ -85,7 +102,7 @@ class TodoApiRouteHandler:
         def get_todo(
             todo_id: UUID,
             usecase: FindTodoByIdUseCase = Depends(get_find_todo_by_id_usecase),
-        ):
+        ) -> TodoSchema:
             """Return a single todo by identifier.
 
             Args:
@@ -112,6 +129,9 @@ class TodoApiRouteHandler:
                 ) from exc
             return TodoSchema.from_entity(todo)
 
+    def _register_create_todo_route(self, app: FastAPI) -> None:
+        """Register the route that creates a todo."""
+
         @app.post(
             '/todos',
             response_model=TodoSchema,
@@ -123,7 +143,7 @@ class TodoApiRouteHandler:
         def create_todo(
             data: TodoCreateSchema,
             usecase: CreateTodoUseCase = Depends(get_create_todo_usecase),
-        ):
+        ) -> TodoSchema:
             """Create a todo from the request payload.
 
             Args:
@@ -138,13 +158,11 @@ class TodoApiRouteHandler:
             """
             try:
                 title = TodoTitle(data.title)
-                description = (
-                    TodoDescription(data.description) if data.description else None
-                )
+                description = self._build_todo_description(data.description)
             except ValueError as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e,
+                    detail=str(e),
                 ) from e
 
             try:
@@ -155,6 +173,9 @@ class TodoApiRouteHandler:
                 ) from e
 
             return TodoSchema.from_entity(todo)
+
+    def _register_update_todo_route(self, app: FastAPI) -> None:
+        """Register the route that updates an existing todo."""
 
         @app.put(
             '/todos/{todo_id}',
@@ -170,7 +191,7 @@ class TodoApiRouteHandler:
             todo_id: UUID,
             data: TodoUpdateSchema,
             usecase: UpdateTodoUseCase = Depends(get_update_todo_usecase),
-        ):
+        ) -> TodoSchema:
             """Update a todo identified by the path parameter.
 
             Args:
@@ -188,13 +209,11 @@ class TodoApiRouteHandler:
 
             try:
                 title = TodoTitle(data.title)
-                description = (
-                    TodoDescription(data.description) if data.description else None
-                )
+                description = self._build_todo_description(data.description)
             except ValueError as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=e,
+                    detail=str(e),
                 ) from e
 
             try:
@@ -211,6 +230,9 @@ class TodoApiRouteHandler:
 
             return TodoSchema.from_entity(todo)
 
+    def _register_start_todo_route(self, app: FastAPI) -> None:
+        """Register the route that starts a todo."""
+
         @app.patch(
             '/todos/{todo_id}/start',
             response_model=TodoSchema,
@@ -224,7 +246,7 @@ class TodoApiRouteHandler:
         def start_todo(
             todo_id: UUID,
             usecase: StartTodoUseCase = Depends(get_start_todo_usecase),
-        ):
+        ) -> TodoSchema:
             """Start a todo via the corresponding use case.
 
             Args:
@@ -250,12 +272,20 @@ class TodoApiRouteHandler:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=e.message,
                 ) from e
+            except TodoAlreadyCompletedError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=e.message,
+                ) from e
             except Exception as e:
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 ) from e
 
             return TodoSchema.from_entity(todo)
+
+    def _register_complete_todo_route(self, app: FastAPI) -> None:
+        """Register the route that completes a todo."""
 
         @app.patch(
             '/todos/{todo_id}/complete',
@@ -270,7 +300,7 @@ class TodoApiRouteHandler:
         def complete_todo(
             todo_id: UUID,
             usecase: CompleteTodoUseCase = Depends(get_complete_todo_usecase),
-        ):
+        ) -> TodoSchema:
             """Complete a todo via the corresponding use case.
 
             Args:
@@ -291,7 +321,7 @@ class TodoApiRouteHandler:
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=e.message,
                 ) from e
-            except TodoAlreadyStartedError as e:
+            except TodoNotStartedError as e:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=e.message,

--- a/dddpy/usecase/todo/__init__.py
+++ b/dddpy/usecase/todo/__init__.py
@@ -1,20 +1,12 @@
 """This package provides use cases for Todo entity operations."""
 
-from dddpy.usecase.todo.create_todo_usecase import (
-    CreateTodoUseCase,
-    new_create_todo_usecase,
-)
-from dddpy.usecase.todo.start_todo_usecase import (
-    StartTodoUseCase,
-    new_start_todo_usecase,
-)
 from dddpy.usecase.todo.complete_todo_usecase import (
     CompleteTodoUseCase,
     new_complete_todo_usecase,
 )
-from dddpy.usecase.todo.update_todo_usecase import (
-    UpdateTodoUseCase,
-    new_update_todo_usecase,
+from dddpy.usecase.todo.create_todo_usecase import (
+    CreateTodoUseCase,
+    new_create_todo_usecase,
 )
 from dddpy.usecase.todo.delete_todo_usecase import (
     DeleteTodoUseCase,
@@ -27,6 +19,14 @@ from dddpy.usecase.todo.find_todo_by_id_usecase import (
 from dddpy.usecase.todo.find_todos_usecase import (
     FindTodosUseCase,
     new_find_todos_usecase,
+)
+from dddpy.usecase.todo.start_todo_usecase import (
+    StartTodoUseCase,
+    new_start_todo_usecase,
+)
+from dddpy.usecase.todo.update_todo_usecase import (
+    UpdateTodoUseCase,
+    new_update_todo_usecase,
 )
 
 __all__ = [

--- a/dddpy/usecase/todo/create_todo_usecase.py
+++ b/dddpy/usecase/todo/create_todo_usecase.py
@@ -1,7 +1,6 @@
 """Provide use case implementations for creating todos."""
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from dddpy.domain.todo.entities import Todo
 from dddpy.domain.todo.repositories import TodoRepository
@@ -13,7 +12,7 @@ class CreateTodoUseCase(ABC):
 
     @abstractmethod
     def execute(
-        self, title: TodoTitle, description: Optional[TodoDescription] = None
+        self, title: TodoTitle, description: TodoDescription | None = None
     ) -> Todo:
         """Create a todo using the provided values.
 
@@ -38,7 +37,7 @@ class CreateTodoUseCaseImpl(CreateTodoUseCase):
         self.todo_repository = todo_repository
 
     def execute(
-        self, title: TodoTitle, description: Optional[TodoDescription] = None
+        self, title: TodoTitle, description: TodoDescription | None = None
     ) -> Todo:
         """Create, persist, and return a new todo entity.
 

--- a/dddpy/usecase/todo/find_todos_usecase.py
+++ b/dddpy/usecase/todo/find_todos_usecase.py
@@ -1,7 +1,6 @@
 """Provide use case implementations for listing todos."""
 
 from abc import ABC, abstractmethod
-from typing import List
 
 from dddpy.domain.todo.entities import Todo
 from dddpy.domain.todo.repositories import TodoRepository
@@ -11,7 +10,7 @@ class FindTodosUseCase(ABC):
     """Define the application boundary for listing todos."""
 
     @abstractmethod
-    def execute(self) -> List[Todo]:
+    def execute(self) -> list[Todo]:
         """Return the collection of todos managed by the system.
 
         Returns:
@@ -30,7 +29,7 @@ class FindTodosUseCaseImpl(FindTodosUseCase):
         """
         self.todo_repository = todo_repository
 
-    def execute(self) -> List[Todo]:
+    def execute(self) -> list[Todo]:
         """Return all todos ordered per repository implementation."""
         return self.todo_repository.find_all()
 

--- a/dddpy/usecase/todo/update_todo_usecase.py
+++ b/dddpy/usecase/todo/update_todo_usecase.py
@@ -1,7 +1,6 @@
 """Provide use case implementations for updating todos."""
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from dddpy.domain.todo.entities import Todo
 from dddpy.domain.todo.exceptions import TodoNotFoundError
@@ -16,8 +15,8 @@ class UpdateTodoUseCase(ABC):
     def execute(
         self,
         todo_id: TodoId,
-        title: Optional[TodoTitle] = None,
-        description: Optional[TodoDescription] = None,
+        title: TodoTitle | None = None,
+        description: TodoDescription | None = None,
     ) -> Todo:
         """Update a todo using the provided values.
 
@@ -45,8 +44,8 @@ class UpdateTodoUseCaseImpl(UpdateTodoUseCase):
     def execute(
         self,
         todo_id: TodoId,
-        title: Optional[TodoTitle] = None,
-        description: Optional[TodoDescription] = None,
+        title: TodoTitle | None = None,
+        description: TodoDescription | None = None,
     ) -> Todo:
         """Update a todo and persist the changes.
 

--- a/tests/domain/todo/entities/test_todo.py
+++ b/tests/domain/todo/entities/test_todo.py
@@ -1,6 +1,6 @@
 """Test cases for the Todo entity."""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 

--- a/tests/domain/todo/value_objects/test_todo_id.py
+++ b/tests/domain/todo/value_objects/test_todo_id.py
@@ -2,16 +2,16 @@
 
 from uuid import UUID
 
-import pytest
-
 from dddpy.domain.todo.value_objects.todo_id import TodoId
+
+UUID4_VERSION = 4
 
 
 def test_generate_creates_valid_uuid():
     """Test that generate() creates a valid UUID."""
     todo_id = TodoId.generate()
     assert isinstance(todo_id.value, UUID)
-    assert todo_id.value.version == 4  # Check if it's a UUID4
+    assert todo_id.value.version == UUID4_VERSION
 
 
 def test_generate_creates_unique_ids():

--- a/tests/domain/todo/value_objects/test_todo_status.py
+++ b/tests/domain/todo/value_objects/test_todo_status.py
@@ -2,6 +2,8 @@
 
 from dddpy.domain.todo.value_objects.todo_status import TodoStatus
 
+EXPECTED_TODO_STATUS_COUNT = 3
+
 
 def test_todo_status_values():
     """Test that TodoStatus has the correct values."""
@@ -12,7 +14,7 @@ def test_todo_status_values():
 
 def test_todo_status_enum_members():
     """Test that TodoStatus has the correct enum members."""
-    assert len(TodoStatus) == 3
+    assert len(TodoStatus) == EXPECTED_TODO_STATUS_COUNT
     assert TodoStatus.NOT_STARTED in TodoStatus
     assert TodoStatus.IN_PROGRESS in TodoStatus
     assert TodoStatus.COMPLETED in TodoStatus

--- a/tests/usecase/todo/test_complete_todo_usecase.py
+++ b/tests/usecase/todo/test_complete_todo_usecase.py
@@ -1,7 +1,6 @@
 """Test cases for CompleteTodoUseCaseImpl."""
 
-from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/usecase/todo/test_create_todo_usecase.py
+++ b/tests/usecase/todo/test_create_todo_usecase.py
@@ -1,10 +1,9 @@
 """Test cases for CreateTodoUseCaseImpl."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
-from dddpy.domain.todo.entities import Todo
 from dddpy.domain.todo.repositories import TodoRepository
 from dddpy.domain.todo.value_objects import TodoDescription, TodoTitle
 from dddpy.usecase.todo.create_todo_usecase import CreateTodoUseCaseImpl

--- a/tests/usecase/todo/test_delete_todo_usecase.py
+++ b/tests/usecase/todo/test_delete_todo_usecase.py
@@ -1,6 +1,6 @@
 """Test cases for DeleteTodoUseCaseImpl."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/usecase/todo/test_find_todo_by_id_usecase.py
+++ b/tests/usecase/todo/test_find_todo_by_id_usecase.py
@@ -1,6 +1,6 @@
 """Test cases for FindTodoByIdUseCaseImpl."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/usecase/todo/test_find_todos_usecase.py
+++ b/tests/usecase/todo/test_find_todos_usecase.py
@@ -1,6 +1,6 @@
 """Test cases for FindTodosUseCaseImpl."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -56,7 +56,7 @@ def test_find_todos_with_items(find_todos_usecase, todo_repository_mock):
     result = find_todos_usecase.execute()
 
     # Assert
-    assert len(result) == 2
+    assert len(result) == len(todos)
     assert result[0].title == todos[0].title
     assert result[1].title == todos[1].title
     todo_repository_mock.find_all.assert_called_once()

--- a/tests/usecase/todo/test_start_todo_usecase.py
+++ b/tests/usecase/todo/test_start_todo_usecase.py
@@ -1,6 +1,6 @@
 """Test cases for StartTodoUseCaseImpl."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/usecase/todo/test_update_todo_usecase.py
+++ b/tests/usecase/todo/test_update_todo_usecase.py
@@ -1,6 +1,6 @@
 """Test cases for UpdateTodoUseCaseImpl."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 


### PR DESCRIPTION
## Summary

This PR enables repository-wide `ruff check .` enforcement in CI and removes the existing Ruff violations that were preventing that from being a reliable quality gate.

The original motivation came from review feedback: the SQLAlchemy-related files touched in the previous work were already Ruff-clean, but the repository as a whole still had outstanding lint findings. Instead of documenting that exception and leaving the gap in place, this change clears the backlog and makes Ruff part of the normal CI flow.

## What changed

- added a dedicated `make lint` target so Ruff can be run consistently in local development and CI
- added a matching `mise` task for the same repository-wide lint command
- updated the GitHub Actions workflow to run Ruff before the type check and test steps
- fixed the remaining repository-wide Ruff findings rather than limiting checks to the recently touched files
- applied the required cleanup across domain, use case, infrastructure, presentation, and test code

## Implementation notes

Most of the cleanup is mechanical and intended to make the codebase compatible with the currently configured Ruff rule set:

- modernized type annotations and import usage
- removed unused imports and formatting issues
- replaced hard-coded comparison values that Ruff flagged with named constants where appropriate
- reduced route registration complexity by splitting the large FastAPI route registration method into smaller helper methods
- simplified the `Todo` entity implementation so it remains lint-clean without introducing ignore rules

While doing that cleanup, I also aligned a couple of HTTP error branches with the corresponding use case behavior so the route handler continues to return the expected `400` responses for invalid lifecycle transitions.

## Why this approach

The alternative would have been to keep CI scoped to only a subset of files or to add temporary exclusions. That would preserve the existing gap and make future enforcement harder.

By fixing the current backlog now and turning on repository-wide Ruff checks in CI, we get a straightforward rule going forward: new changes should keep the entire repository lint-clean.

## Impact

- CI now fails when new Ruff errors or warnings are introduced anywhere in the repository
- local development now has an explicit `make lint` / `mise run lint` entry point
- no intentional feature changes were introduced; the primary goal is quality-gate enforcement and lint debt removal

## Validation

- `make format`
- `make lint`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Todo API endpoints, including better validation for already-completed and not-started todo states.

* **Chores**
  * Added linting infrastructure and modernized codebase type annotations to current Python standards.
  * Refactored code organization with improved constant definitions for validation messages and limits.
  * Cleaned up unused test imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->