### PR TITLE
[codex] chore(ci): update setup-python for Node 24

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: A workflow to run tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -11,10 +14,8 @@ jobs:
         python-version: [3.13, 3.14]
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.ref }}
       - name: Use Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv


### PR DESCRIPTION
## Summary
- bump `actions/setup-python` from `v5` to `v6` in the test workflow
- add explicit read-only `contents` permissions for least-privilege workflow execution
- remove the redundant `ref: ${{ github.ref }}` override from `actions/checkout`

## Root cause
GitHub Actions is warning because `actions/setup-python@v5` still runs on the deprecated Node.js 20 runtime. The `v6` release updates the action for Node.js 24 compatibility, which aligns the workflow with the upcoming GitHub-hosted runner runtime change.

## Impact
This removes the Node.js 20 deprecation warning from the Python test workflow without changing the project test matrix or validation steps.

## Validation
- `make format`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by implementing stricter permission configurations, reducing potential security risks.
  * Upgraded testing infrastructure components to latest stable versions for improved reliability and performance.
  * Streamlined workflow configuration for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->